### PR TITLE
Adding linux to package support

### DIFF
--- a/libvulkan-meta/libvulkan-meta/buildfile
+++ b/libvulkan-meta/libvulkan-meta/buildfile
@@ -33,6 +33,8 @@ switch $c.target.class
 
         vulkan_poptions += -DVK_PROTOTYPES
     }
+    case 'linux'
+    case 'bsd'
     case 'macos'
     {
         if($config.libvulkan_meta.sdk_root != "")
@@ -43,8 +45,6 @@ switch $c.target.class
 
         vulkan_libs += -lvulkan
     }
-    case 'linux'
-    case 'bsd'
     default
     {
         vulkan_libs += -lvulkan


### PR DESCRIPTION
Moved the `linux` and `bsd` switch cases up so that they use the same include logic as macos. This should allow the `VULKAN_SDK` environment variable to work as intented.

Fixes #8 